### PR TITLE
update Fast API and replace all the deprecated functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 status.json
 __pycache__
 *.sw[a-p]
+.env

--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ A cooler and furnace controller run by a RaspberryPi with wireless arduino-based
 ![image](https://github.com/user-attachments/assets/b730898e-81bf-48fd-b9f2-f95659548468)
 
 ## About
-This project was created to solve two problems. The first being that I wanted to be able to control my evaporative cooler and furnace with a single thermostat, and I was unable to find a commercially available thermostat that could do that. The second problem is the wiring for the thermostats in my residence were installed too close to the vents. As a result, the thermostats' temperature readings were terribly inaccurate.
+This project was created to solve two problems:
+
+1. There does not seem to be a consumer-available thermostat for controlling both a furnace and evaporative cooler. This requires two separate thermostats which can be difficult to control and requires the user to remember to turn one off when turning the other off.
+
+2. Most thermostats have one temperature sensor integrated into the thermostat. This means if the wiring is located an inoptimal location such as near a vent, the thermostat will never have an accurate reading of the temperature of the residence.
+
+This thermostat aims to solve these problems. It uses a Raspberry Pi to control the appliances and is fairly unconcerned about what they are making only the distinction between whether they cool or heat allowing it to control a furnace, evaporative cooler, and air conditioner. It also utilizes ESP8266 flashed with Arduino firmware as temperature sensors to monitor the temperature in multiple rooms simultaneously or a single, more optimal location.
 
 ### Hardware used
 * RaspberryPi
@@ -31,11 +37,11 @@ The thermostat gathers temperature data from multiple ESP8266 modules. The tempe
 
 #### Dependencies
 apt requirements:  
-build-essential libgpiod2 python3-rpi.gpio python3-systemd apache2 libsystemd-dev
+build-essential libgpiod2 python3-rpi.gpio python3-systemd nginx libsystemd-dev
 
  - `cd rpi-thermostat/daemon`
  - Setup a virtual environment `python -m venv .env`
- - Activate the virtual env `source ~/.env/bin/activate`
+ - Activate the virtual environment `source ~/.env/bin/activate`
  - Install dependencies `pip install -r requirements.txt`
 
 #### Daemon setup:
@@ -43,50 +49,30 @@ build-essential libgpiod2 python3-rpi.gpio python3-systemd apache2 libsystemd-de
 ##### Development
 
 1. cd into the `daemon` directory of the project
-2. run `python -m uvicorn --host 0.0.0.0 main:app --reload`
-   - For HTTPS
-       - Generate a key and crt file with OpenSSL
-       - Instead, run `python -m uvicorn --host 0.0.0.0 main:app --ssl-keyfile ~/daemon-selfsigned.key --ssl-certfile ~/daemon-selfsigned.crt --reload` (adjust the file paths accordingly)
+2. Ensure you've activated the virtual environment
+2. run `fastapi dev --port 8001 --host 127.0.0.1 main.py`
 
 ##### Production
 
 - Copy `thermostat.service` to `/etc/systemd/system`
-- For HTTPS, generate a key and crt file with OpenSSL. `thermostat.service` by default expects these files to be located in `/home/pi/daemon-selfsigned.*`.
-- Edit the `thermostat.service` file with appropriate user, group, paths to key and cert files, and working directory path
+- Edit the `thermostat.service` file 
+    - Replace user and group with the appropriate user and group. Ideally a user that is not a sudoer
+    - Replace the two paths with a path to the daemon directory on the machine
 - Run `sudo systemctl daemon-reload` or reboot
 - Run `sudo systemctl enable thermostat` to enable the service
 
 The service will start on boot and automatically restart if anything goes wrong
 
-#### Webapp setup:
+#### Webapp and SSL proxy setup:
 
-install apache2 and make sure it is running
-
-copy the contents of the webapp directory to `/var/www/html/`
-
-run `sudo systemctl restart apache2`
-
-##### Setting up HTTPS with self-signed certificates:
-This section is slightly modified from [this tutorial](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-apache-in-ubuntu-16-04)
-
-1. Enable mode_ssl and restart apache server
-    1. `sudo a2enmod ssl`
-    2. `sudo systemctl restart apache2`
+1. Install nginx `sudo apt install nginx`
+2. Ensure nginx is running `sudo systemctl status nginx`
+3. Copy the contents of the webapp directory to `/var/www/html`
 2. Generate the SSL Certificate
-    1. `sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/apache-selfsigned.key -out /etc/ssl/certs/apache-selfsigned.crt -subj '/CN=localhost'`
+    1. `sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt -subj '/CN=localhost'`
     2. Make sure to replace "localhost" in the command with the address/domain name used to access the webapp.
-3. Configure Apache
-    1. Create and edit the conf file `/etc/apache2/sites-available/your_domain_or_ip.conf`
-    2. ```
-        <VirtualHost *:443>
-            ServerName your_domain_or_ip
-            DocumentRoot /var/www/html
-
-            SSLEngine on
-            SSLCertificateFile /etc/ssl/certs/apache-selfsigned.crt
-            SSLCertificateKeyFile /etc/ssl/private/apache-selfsigned.key
-        </VirtualHost>```
-    
-    3. Enable the confuration file
-      1. `sudo a2ensite /etc/apache2/sites-available/your_domain_or_ip.conf`
-      2. `sudo systemctl reload apache2`
+3. Configure Nginx
+    1. Edit the nginx.conf file
+        1. Replace `<server domain>` with the server's IP address or domain.
+        2. Replace `<fastapi-port>` with the port set in `thermostat.service`
+    2. Copy the file to `/etc/nginx/sites-available/<server.ip>`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The thermostat gathers temperature data from multiple ESP8266 modules. The tempe
 
 ## Setup Instructions
 
+
 ### Arduino setup:
 
 1. Add and install [ESP8266](https://github.com/esp8266/Arduino).
@@ -30,10 +31,12 @@ The thermostat gathers temperature data from multiple ESP8266 modules. The tempe
 
 #### Dependencies
 apt requirements:  
-build-essential python-dev git libgpiod2 python3-rpi.gpio python3-systemd apache2
+build-essential libgpiod2 python3-rpi.gpio python3-systemd apache2 libsystemd-dev
 
-pip requirements:  
-adafruit-circuitpython-dht fastapi-restful uvicorn[standard] 
+ - `cd rpi-thermostat/daemon`
+ - Setup a virtual environment `python -m venv .env`
+ - Activate the virtual env `source ~/.env/bin/activate`
+ - Install dependencies `pip install -r requirements.txt`
 
 #### Daemon setup:
 

--- a/daemon/controller.py
+++ b/daemon/controller.py
@@ -1,4 +1,3 @@
-import adafruit_dht
 import board
 import RPi.GPIO as GPIO
 import models
@@ -37,7 +36,6 @@ class Controller:
     GPIO.setup(AC_PIN, GPIO.OUT, initial=OFF)
     GPIO.setup(FURNACE_PIN, GPIO.OUT, initial=OFF)
 
-    self._dht = adafruit_dht.DHT22(board.D4, use_pulseio=False)
     self.last_update_time = None
     self.history = []
 
@@ -56,37 +54,6 @@ class Controller:
 
   def get_history(self):
     return self.history
-
-
-  def get_temperature(self):
-    for i in range(3):
-      try:
-        temperature_c = self._dht.temperature
-        if temperature_c:
-          temperature_f = temperature_c * (9 / 5) + 32
-          log.info("temperature: {}".format(temperature_f))
-          print("temperature: {}".format(temperature_f))
-          return round(temperature_f, 3)
-      except:
-        log.error("Temperature didn't read, trying again")
-        print("Temperature didn't read, trying again")
-        continue
-    return None
-
-
-  def get_humidity(self):
-    for i in range(3):
-      try:
-        humidity = self._dht.humidity
-        if humidity:
-          log.info("humidity: {}".format(humidity))
-          print("humidity: {}".format(humidity))
-          return humidity
-      except:
-        log.error("Humidity didn't read, trying again")
-        print("Humidity didn't read, trying again")
-        continue
-    return None
 
   
   def set_target_temp(self, temp: int):
@@ -107,14 +74,6 @@ class Controller:
 
   def update_sensor_status(self, name: str, temp: float, humidity: float):
     self.status.sensors[name] = {"humidity": humidity, "temperature": temp, "timestamp": time.time()}
-
-
-  def update_local_sensor(self):
-    temperature = self.get_temperature()
-    humidity = self.get_humidity()
-    log.info("{} {}".format(temperature, humidity))
-    if humidity and temperature:
-      self.status.sensors["Closet"] = {"humidity": humidity, "temperature": temperature, "timestamp": time.time()}
 
 
   def drive_status(self):

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -1,22 +1,51 @@
 from fastapi import FastAPI, Response, status
-from fastapi_restful.tasks import repeat_every
+from fastapi_utils.tasks import repeat_every
 from fastapi.middleware.cors import CORSMiddleware
+from contextlib import asynccontextmanager
 from pydantic import BaseModel
+import asyncio
 
 from controller import Controller
 import ssl
 import models
 
-app = FastAPI()
+
+is_shutdown = False
 controller = Controller()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global is_shutdown
+    print("the lifespan is happening")
+    asyncio.create_task(drive_status_loop())
+    asyncio.create_task(drive_history_loop())
+    yield
+    print("post-yield")
+    is_shutdown = True
+
+app = FastAPI(lifespan=lifespan)
+
+async def drive_status_loop():
+  global is_shutdown
+  while (not is_shutdown):
+    print("Driving status loop")
+    drive_status()
+    await asyncio.sleep(10)
+
+async def drive_history_loop():
+  global is_shutdown
+  while (not is_shutdown):
+    print("Driving history loop")
+    controller.update_history()
+    await asyncio.sleep(10)
+
 
 origins = [
   "*",
   "https://raspberrypi.local"
 ]
 
-ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-ssl_context.load_cert_chain('/home/pi/daemon-selfsigned.crt', keyfile='/home/pi/daemon-selfsigned.key')
+
 
 app.add_middleware(
   CORSMiddleware,
@@ -26,16 +55,12 @@ app.add_middleware(
   allow_headers=["*"],
 )
 
-@app.on_event("startup")
-@repeat_every(seconds=10)
-async def drive_status():
-  controller.drive_status()
 
-
-@app.on_event("startup")
-@repeat_every(seconds=120)
-async def drive_history():
-  controller.update_history()
+def drive_status():
+  try:
+    controller.drive_status()
+  except asyncio.CancelledError:
+    print("the exception accepted successfully")
 
 
 @app.get("/", response_model=models.StatusObject)
@@ -48,7 +73,7 @@ async def get_temperature() -> float:
   return controller.get_temperature()
 
 @app.get("/history")
-async def get_history() -> dict:
+async def get_history() -> models.HistoryObject:
   return models.HistoryObject(history = controller.get_history())
 
 @app.put("/sensor-status")

--- a/daemon/requirements.txt
+++ b/daemon/requirements.txt
@@ -1,3 +1,4 @@
+adafruit-circuitpython-dht
 fastapi[standard]
 fastapi-utils
 typing_inspect

--- a/daemon/requirements.txt
+++ b/daemon/requirements.txt
@@ -1,4 +1,3 @@
-adafruit-circuitpython-dht
 fastapi[standard]
 fastapi-utils
 typing_inspect

--- a/daemon/requirements.txt
+++ b/daemon/requirements.txt
@@ -1,3 +1,5 @@
 adafruit-circuitpython-dht
-fastapi-restful
-uvicorn[standard]
+fastapi[standard]
+fastapi-utils
+typing_inspect
+systemd-python

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,8 @@
+domainname = 
+fastapi-port = 
+
+
+
 server {
     server_name <server domain>;
     
@@ -28,6 +33,6 @@ server {
     server_name <server domain>;
     listen 443 ssl;
     root /var/www/html;
-    ssl_certificate <path/to/cert>;
-    ssl_certificate_key <path/to/key>;
+    ssl_certificate /etc/ssl/private/nginx-selfsigned.key;
+    ssl_certificate_key /etc/ssl/certs/nginx-selfsigned.crt;
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    server_name <server domain>;
+    
+    error_log /var/log/nginx/error.log warn;
+
+    location / {
+        proxy_pass http://127.0.0.1:<fastapi-port>; # should match with the fastapi port
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    listen 8000 ssl;
+    ssl_certificate <path/to/cert>;
+    ssl_certificate_key <path/to/key>;
+}
+
+server {
+    if ($host = <server domain>) {
+        return 301 https://$host$request_uri;
+    }
+
+    listen 80;
+    server_name <server domain>;
+}
+
+server {
+    server_name <server domain>;
+    listen 443 ssl;
+    root /var/www/html;
+    ssl_certificate <path/to/cert>;
+    ssl_certificate_key <path/to/key>;
+}

--- a/thermostat.service
+++ b/thermostat.service
@@ -2,12 +2,13 @@
 Description=Python Daemon to control swamp cooler and furnace via FastAPI
 
 [Service]
-User=pi
-Group=pi
-ExecStart=python3 -m uvicorn main:app --ssl-keyfile ~/daemon-selfsigned.key --ssl-certfile ~/daemon-selfsigned.crt --host=0.0.0.0
-WorkingDirectory=/home/pi/rpi-thermostat/daemon/
+User=<user>
+Group=<group>
+ExecStart=<path/to/thermostat/directory>/daemon/.env/bin/fastapi run --port 8001 --host 127.0.0.1 main.py
+WorkingDirectory=<path/to/thermostat/directory>/daemon/
 Restart=always
 RestartSec=5
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It occurred to me that I haven't updated the python packages and the operating system on the Raspberry Pi in quite a while. I started by updating the OS, which incidentally updated a lot of packages. In this time, FastAPI changed a lot. The way were handling things has changed and quite a few functions we used got deprecated.

FastAPI also dropped support for SSL encryption. This prompted a switch from Apache to Nginx to use Nginx as an HTTPS proxy for the server.