### PR TITLE
Pylint

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -4,6 +4,7 @@ import os
 CONFIG_PATH = "config.ini"
 config = ConfigParser()
 
+
 def load_config():
     # Default values
     defaults = {
@@ -34,7 +35,7 @@ def load_config():
         else:
             config[category] = defaults[category]
             rewrite = True
-    
+
     # Update the config file if necessary
     if rewrite:
         print("Writing config file")

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -1,3 +1,5 @@
+"""Handles IO of config file."""
+
 from configparser import ConfigParser
 import os
 
@@ -6,6 +8,10 @@ config = ConfigParser()
 
 
 def load_config():
+    """
+    Reads config from `CONFIG_PATH`
+    If doesn't exist, creates the file with default values.
+    """
     # Default values
     defaults = {
         'DATABASE': {
@@ -24,12 +30,12 @@ def load_config():
     rewrite = False
 
     # Fill in missing details
-    for category in defaults:
+    for category, items in defaults.items():
         if category in config:
             has_category = category in config
-            for key in defaults[category]:
+            for key in items:
                 if has_category:
-                    if not (key in config[category]):
+                    if key not in config[category]:
                         config[category][key] = defaults[category][key]
                         rewrite = True
         else:
@@ -39,7 +45,7 @@ def load_config():
     # Update the config file if necessary
     if rewrite:
         print("Writing config file")
-        with open(CONFIG_PATH, 'w') as configfile:
+        with open(CONFIG_PATH, 'w', encoding="utf-8") as configfile:
             config.write(configfile)
 
     return config

--- a/daemon/controller.py
+++ b/daemon/controller.py
@@ -1,6 +1,6 @@
-import RPi.GPIO as GPIO
-import models
 import time
+import models
+from RPi import GPIO
 
 PUMP_PIN = 5
 FAN_ON_PIN = 6
@@ -8,202 +8,203 @@ AC_PIN = 12
 FURNACE_PIN = 13
 
 PINS = {
-  "pump": PUMP_PIN,
-  "fan_on": FAN_ON_PIN,
-  "ac": AC_PIN,
-  "furnace": FURNACE_PIN
+    "pump": PUMP_PIN,
+    "fan_on": FAN_ON_PIN,
+    "ac": AC_PIN,
+    "furnace": FURNACE_PIN
 }
 
 ON = GPIO.LOW
 OFF = GPIO.HIGH
 
-CYCLE_TIME = 2 * 60 # minutes converted to seconds
-SENSOR_STALE_TIMEOUT = 1 * 60 # minutes converted to seconds
+CYCLE_TIME = 2 * 60  # minutes converted to seconds
+SENSOR_STALE_TIMEOUT = 1 * 60  # minutes converted to seconds
 HISTORY_MAX_ENTRIES = 500
 
+
 class Controller:
-  def __init__(self, log):
-    GPIO.setmode(GPIO.BCM)
-    GPIO.setup(PUMP_PIN, GPIO.OUT, initial=OFF)
-    GPIO.setup(FAN_ON_PIN, GPIO.OUT, initial=OFF)
-    GPIO.setup(AC_PIN, GPIO.OUT, initial=OFF)
-    GPIO.setup(FURNACE_PIN, GPIO.OUT, initial=OFF)
+    def __init__(self, log):
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(PUMP_PIN, GPIO.OUT, initial=OFF)
+        GPIO.setup(FAN_ON_PIN, GPIO.OUT, initial=OFF)
+        GPIO.setup(AC_PIN, GPIO.OUT, initial=OFF)
+        GPIO.setup(FURNACE_PIN, GPIO.OUT, initial=OFF)
 
-    self.last_update_time = None
-    self.history = []
-    self.log = log
-    
-    try:
-      f = open("status.json", "r")
-      self.status = models.Status.parse_raw(f.read())
-    except Exception:
-      self.log.info("No status file found. Using default values.")
-      print("No status file found. Using default values.")
-      pins = models.Pins(pump = False, fan_on = False, ac = False, furnace = False)
-      usable = models.Usable(ac = True, cooler = True, furnace = True)
-      self.status = models.Status(pins = pins, usable = usable, target_temp = 72, average_temp = 72, manual_override = False, sensors = {})
+        self.last_update_time = None
+        self.history = []
+        self.log = log
 
+        try:
+            f = open("status.json", "r")
+            self.status = models.Status.parse_raw(f.read())
+        except Exception:
+            self.log.info("No status file found. Using default values.")
+            print("No status file found. Using default values.")
+            pins = models.Pins(
+                pump=False,
+                fan_on=False,
+                ac=False,
+                furnace=False)
+            usable = models.Usable(ac=True, cooler=True, furnace=True)
+            self.status = models.Status(
+                pins=pins,
+                usable=usable,
+                target_temp=72,
+                average_temp=72,
+                manual_override=False,
+                sensors={})
 
-  def get_status(self):
-    return self.status
-  
+    def get_status(self):
+        return self.status
 
-  def get_history(self):
-    return self.history
+    def get_history(self):
+        return self.history
 
-  
-  def set_target_temp(self, temp: int):
-    self.log.info("target temp set to {}".format(temp))
-    print("target temp set to {}".format(temp))
-    self.status.target_temp = temp
+    def set_target_temp(self, temp: int):
+        self.log.info("target temp set to {}".format(temp))
+        print("target temp set to {}".format(temp))
+        self.status.target_temp = temp
 
+    def set_usable(self, ac: bool, cooler: bool, furnace: bool):
+        usable = models.Usable(ac=ac, cooler=cooler, furnace=furnace)
+        self.status.usable = usable
 
-  def set_usable(self, ac: bool, cooler: bool, furnace: bool):
-    usable = models.Usable(ac = ac, cooler = cooler, furnace = furnace)
-    self.status.usable = usable
+    def set_manual_override(self, override: bool, pins: models.Pins):
+        self.status.manual_override = override
+        self.set_pins(pins.pump, pins.fan_on, pins.ac, pins.furnace)
 
+    def update_sensor_status(self, name: str, temp: float, humidity: float):
+        self.status.sensors[name] = {
+            "humidity": humidity,
+            "temperature": temp,
+            "timestamp": time.time()}
 
-  def set_manual_override(self, override: bool, pins: models.Pins):
-    self.status.manual_override = override
-    self.set_pins(pins.pump, pins.fan_on, pins.ac, pins.furnace)
+    def drive_status(self):
+        try:
+            self.remove_stale_sensors()
+            self.status.average_temp = self.get_average_temp()
+            if not self.status.manual_override:
+                if (self.last_update_time is None or time.time() -
+                        self.last_update_time >= CYCLE_TIME):
+                    temp_diff = self.status.average_temp - self.status.target_temp
+                    if self.status.pins.ac or self.status.pins.fan_on:
+                        if self.status.usable.ac:
+                            if temp_diff <= 1:
+                                self.all_off()
+                                self.last_update_time = time.time()
+                            else:
+                                self.ac_on()
+                        elif self.status.usable.cooler:
+                            if temp_diff <= 1:
+                                self.all_off()
+                                self.last_update_time = time.time()
+                            else:
+                                self.fan_low_on()
+                        else:
+                            self.all_off()
+                    elif self.status.pins.furnace:
+                        if temp_diff >= -1:
+                            self.all_off()
+                            self.last_update_time = time.time()
+                        else:
+                            self.furnace_on()
+                    else:
+                        if temp_diff <= -2:
+                            self.furnace_on()
+                            self.last_update_time = time.time()
+                        elif temp_diff >= 2:
+                            if self.status.usable.ac:
+                                self.ac_on()
+                                self.last_update_time = time.time()
+                            elif self.status.usable.cooler:
+                                self.fan_low_on()
+                                self.last_update_time = time.time()
+                        else:
+                            self.all_off()
 
+            self.write_status()
+        except Exception as e:
+            self.log.critical(str(e))
+            print(str(e))
 
-  def update_sensor_status(self, name: str, temp: float, humidity: float):
-    self.status.sensors[name] = {"humidity": humidity, "temperature": temp, "timestamp": time.time()}
+    def update_history(self):
+        self.log.info("Updating history " + str(self.status.average_temp))
+        print("Updating history " + str(self.status.average_temp))
+        time_obj = time.localtime()
+        time_asc = time.asctime(time_obj)
+        self.history.append((time_asc, self.status.average_temp))
+        if len(self.history) > HISTORY_MAX_ENTRIES:
+            to_remove = len(self.history) - HISTORY_MAX_ENTRIES
+            self.history = self.history[to_remove:]
 
+    def remove_stale_sensors(self):
+        sensor_keys = self.status.sensors.keys()
+        sensors_to_remove = []
+        for key in sensor_keys:
+            if self.status.sensors[key]["timestamp"] + \
+                    SENSOR_STALE_TIMEOUT <= time.time():
+                sensors_to_remove.append(key)
+        for key in sensors_to_remove:
+            self.status.sensors.pop(key)
 
-  def drive_status(self):
-    try:
-      self.remove_stale_sensors()
-      self.status.average_temp = self.get_average_temp()
-      if not self.status.manual_override:
-        if (self.last_update_time == None or time.time() - self.last_update_time >= CYCLE_TIME):
-          temp_diff = self.status.average_temp - self.status.target_temp
-          if self.status.pins.ac == True or self.status.pins.fan_on == True:
-            if self.status.usable.ac:
-              if temp_diff <= 1:
-                self.all_off()
-                self.last_update_time = time.time()
-              else:
-                self.ac_on()
-            elif self.status.usable.cooler:
-              if temp_diff <= 1:
-                self.all_off()
-                self.last_update_time = time.time()
-              else:
-                self.fan_low_on()
-            else:
-              self.all_off()
-          elif self.status.pins.furnace == True:
-            if temp_diff >= -1:
-              self.all_off()
-              self.last_update_time = time.time()
-            else:
-              self.furnace_on()
-          else:
-            if temp_diff <= -2:
-              self.furnace_on()
-              self.last_update_time = time.time()
-            elif temp_diff >= 2:
-              if self.status.usable.ac:
-                self.ac_on()
-                self.last_update_time = time.time()
-              elif self.status.usable.cooler:
-                self.fan_low_on()
-                self.last_update_time = time.time()
-            else:
-              self.all_off()
-      
-      self.write_status()
-    except Exception as e:
-      self.log.critical(str(e))
-      print(str(e))
+    def get_average_temp(self):
+        temp_sum = 0
+        sensor_keys = self.status.sensors.keys()
+        for key in sensor_keys:
+            temp_sum += self.status.sensors[key]["temperature"]
+        return temp_sum / len(sensor_keys)
 
+    def fan_low_on(self):
+        self.log.info("Turning on cooler to low")
+        print("Turning on cooler to low")
+        if self.status.usable.cooler:
+            self.set_pins(True, True, False, False)
+        else:
+            self.all_off()
 
-  def update_history(self):
-    self.log.info("Updating history " + str(self.status.average_temp))
-    print("Updating history " + str(self.status.average_temp))
-    time_obj = time.localtime()
-    time_asc = time.asctime(time_obj)
-    self.history.append((time_asc, self.status.average_temp))
-    if len(self.history) > HISTORY_MAX_ENTRIES:
-      to_remove = len(self.history) - HISTORY_MAX_ENTRIES
-      self.history = self.history[to_remove:]
+    def ac_on(self):
+        self.log.info("Turning on ac")
+        print("Turning on ac")
+        if self.status.usable.ac:
+            self.set_pins(False, False, True, False)
+        else:
+            self.all_off()
 
+    def furnace_on(self):
+        self.log.info("Turning on furnace")
+        print("Turning on furnace")
+        if self.status.usable.furnace:
+            self.set_pins(False, False, False, True)
+        else:
+            self.all_off()
 
-  def remove_stale_sensors(self):
-    sensor_keys = self.status.sensors.keys()
-    sensors_to_remove = []
-    for key in sensor_keys:
-      if self.status.sensors[key]["timestamp"] + SENSOR_STALE_TIMEOUT <= time.time():
-        sensors_to_remove.append(key)
-    for key in sensors_to_remove:
-        self.status.sensors.pop(key)
+    def all_off(self):
+        self.log.info("Turning cooler and furnace off")
+        print("Turning cooler and furnace off")
+        self.set_pins(False, False, False, False)
 
+    def set_pins(self, pump: bool, fan_on: bool, ac: bool, furnace: bool):
+        pins_status = models.Pins(
+            pump=pump, fan_on=fan_on, ac=ac, furnace=furnace)
+        self.status.pins = pins_status
+        pump_pin = OFF
+        fan_on_pin = OFF
+        ac_pin = OFF
+        furnace_pin = OFF
+        if pump:
+            pump_pin = ON
+        if fan_on:
+            fan_on_pin = ON
+        if ac:
+            ac_pin = ON
+        if furnace:
+            furnace_pin = ON
+        GPIO.output(PUMP_PIN, pump_pin)
+        GPIO.output(FAN_ON_PIN, fan_on_pin)
+        GPIO.output(AC_PIN, ac_pin)
+        GPIO.output(FURNACE_PIN, furnace_pin)
 
-  def get_average_temp(self):
-    temp_sum = 0
-    sensor_keys = self.status.sensors.keys()
-    for key in sensor_keys:
-      temp_sum += self.status.sensors[key]["temperature"]
-    return temp_sum / len(sensor_keys)
-
-
-  def fan_low_on(self):
-    self.log.info("Turning on cooler to low")
-    print("Turning on cooler to low")
-    if self.status.usable.cooler:
-      self.set_pins(True, True, False, False)
-    else:
-      self.all_off()
-
-
-  def ac_on(self):
-    self.log.info("Turning on ac")
-    print("Turning on ac")
-    if self.status.usable.ac:
-      self.set_pins(False, False, True, False)
-    else:
-      self.all_off()
-
-
-  def furnace_on(self):
-    self.log.info("Turning on furnace")
-    print("Turning on furnace")
-    if self.status.usable.furnace:
-      self.set_pins(False, False, False, True)
-    else:
-      self.all_off()
-
-
-  def all_off(self):
-    self.log.info("Turning cooler and furnace off")
-    print("Turning cooler and furnace off")
-    self.set_pins(False, False, False, False)
-
-
-  def set_pins(self, pump: bool, fan_on: bool, ac: bool, furnace: bool):
-    pins_status = models.Pins(pump = pump, fan_on = fan_on, ac = ac, furnace = furnace)
-    self.status.pins = pins_status
-    pump_pin = OFF
-    fan_on_pin = OFF
-    ac_pin = OFF
-    furnace_pin = OFF
-    if pump:
-      pump_pin = ON
-    if fan_on:
-      fan_on_pin = ON
-    if ac:
-      ac_pin = ON
-    if furnace:
-      furnace_pin = ON
-    GPIO.output(PUMP_PIN, pump_pin)
-    GPIO.output(FAN_ON_PIN, fan_on_pin)
-    GPIO.output(AC_PIN, ac_pin)
-    GPIO.output(FURNACE_PIN, furnace_pin)
-
-  def write_status(self):
-    f = open("status.json", "w")
-    f.write(self.status.json())
-    f.close()
-
+    def write_status(self):
+        f = open("status.json", "w")
+        f.write(self.status.json())
+        f.close()

--- a/daemon/controller.py
+++ b/daemon/controller.py
@@ -1,6 +1,16 @@
+"""
+Controller class is responsible for the following things:
+ - Keep track of each sensor's temperature
+ - Keep track of the state of the thermostat
+ - Change the state based on average temperature of the thermostat
+ - Write to the GPIO pins
+ - Write the state to a JSON file
+ - Keep track of average temperature's history over time
+"""
+
 import time
-import models
 from RPi import GPIO
+import models
 
 PUMP_PIN = 5
 FAN_ON_PIN = 6
@@ -23,6 +33,7 @@ HISTORY_MAX_ENTRIES = 500
 
 
 class Controller:
+    """Handles keeping track of status and controlling the thermostat"""
     def __init__(self, log):
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(PUMP_PIN, GPIO.OUT, initial=OFF)
@@ -35,8 +46,9 @@ class Controller:
         self.log = log
 
         try:
-            f = open("status.json", "r")
-            self.status = models.Status.parse_raw(f.read())
+            # f = open("status.json", "r", encoding="utf-8")
+            with open("status.json", "r", encoding="utf-8") as file:
+                self.status = models.Status.parse_raw(file.read())
         except Exception:
             self.log.info("No status file found. Using default values.")
             print("No status file found. Using default values.")
@@ -54,35 +66,55 @@ class Controller:
                 manual_override=False,
                 sensors={})
 
-    def get_status(self):
+    def get_status(self) -> models.Status:
+        """Returns current status of thermostat including temperatures."""
         return self.status
 
-    def get_history(self):
+    def get_history(self) -> list:
+        """
+        Gets the history of the average temperatures
+        Returns a list of tuples containing timestamps and temperature.
+        """
         return self.history
 
-    def set_target_temp(self, temp: int):
-        self.log.info("target temp set to {}".format(temp))
-        print("target temp set to {}".format(temp))
-        self.status.target_temp = temp
-
-    def set_usable(self, ac: bool, cooler: bool, furnace: bool):
-        usable = models.Usable(ac=ac, cooler=cooler, furnace=furnace)
-        self.status.usable = usable
-
-    def set_manual_override(self, override: bool, pins: models.Pins):
-        self.status.manual_override = override
-        self.set_pins(pins.pump, pins.fan_on, pins.ac, pins.furnace)
-
     def update_sensor_status(self, name: str, temp: float, humidity: float):
+        """Adds or updates an entry to the sensors list keyed by `name`."""
         self.status.sensors[name] = {
             "humidity": humidity,
             "temperature": temp,
             "timestamp": time.time()}
 
+    def set_target_temp(self, temp: int):
+        """Sets the temperature the thermostat aims for."""
+        self.log.info(f"target temp set to f{temp}")
+        print(f"target temp set to f{temp}")
+        self.status.target_temp = temp
+
+    def set_usable(self, ac: bool, cooler: bool, furnace: bool):
+        """Set which systems the thermostat can use."""
+        usable = models.Usable(ac=ac, cooler=cooler, furnace=furnace)
+        self.status.usable = usable
+
+    def set_manual_override(self, override: bool, pins: models.Pins):
+        """
+        Overrides the pins to manually turn them on or off.
+
+        Be careful using this if the system is hooked up to a real HVAC system.
+        """
+        self.status.manual_override = override
+        self._set_pins(pins.pump, pins.fan_on, pins.ac, pins.furnace)
+
+
     def drive_status(self):
+        """
+        This function:
+        1. Calculates the average temperature for all sensors
+        2. Uses the average temperature to set pins accordingly (turning heating/cooling on/off)
+        3. Writes the updated status to a file
+        """
         try:
-            self.remove_stale_sensors()
-            self.status.average_temp = self.get_average_temp()
+            self._remove_stale_sensors()
+            self.status.average_temp = self._get_average_temp()
             if not self.status.manual_override:
                 if (self.last_update_time is None or time.time() -
                         self.last_update_time >= CYCLE_TIME):
@@ -90,46 +122,50 @@ class Controller:
                     if self.status.pins.ac or self.status.pins.fan_on:
                         if self.status.usable.ac:
                             if temp_diff <= 1:
-                                self.all_off()
+                                self._all_off()
                                 self.last_update_time = time.time()
                             else:
-                                self.ac_on()
+                                self._ac_on()
                         elif self.status.usable.cooler:
                             if temp_diff <= 1:
-                                self.all_off()
+                                self._all_off()
                                 self.last_update_time = time.time()
                             else:
-                                self.fan_low_on()
+                                self._fan_low_on()
                         else:
-                            self.all_off()
+                            self._all_off()
                     elif self.status.pins.furnace:
                         if temp_diff >= -1:
-                            self.all_off()
+                            self._all_off()
                             self.last_update_time = time.time()
                         else:
-                            self.furnace_on()
+                            self._furnace_on()
                     else:
                         if temp_diff <= -2:
-                            self.furnace_on()
+                            self._furnace_on()
                             self.last_update_time = time.time()
                         elif temp_diff >= 2:
                             if self.status.usable.ac:
-                                self.ac_on()
+                                self._ac_on()
                                 self.last_update_time = time.time()
                             elif self.status.usable.cooler:
-                                self.fan_low_on()
+                                self._fan_low_on()
                                 self.last_update_time = time.time()
                         else:
-                            self.all_off()
+                            self._all_off()
 
-            self.write_status()
+            self._write_status()
         except Exception as e:
             self.log.critical(str(e))
             print(str(e))
 
     def update_history(self):
-        self.log.info("Updating history " + str(self.status.average_temp))
-        print("Updating history " + str(self.status.average_temp))
+        """
+        Adds the current average temperature to the history list.
+        Deletes oldest entries if maximum has been reached.
+        """
+        self.log.info(f"Updating history f{str(self.status.average_temp)}")
+        print(f"Updating history f{str(self.status.average_temp)}")
         time_obj = time.localtime()
         time_asc = time.asctime(time_obj)
         self.history.append((time_asc, self.status.average_temp))
@@ -137,7 +173,7 @@ class Controller:
             to_remove = len(self.history) - HISTORY_MAX_ENTRIES
             self.history = self.history[to_remove:]
 
-    def remove_stale_sensors(self):
+    def _remove_stale_sensors(self):
         sensor_keys = self.status.sensors.keys()
         sensors_to_remove = []
         for key in sensor_keys:
@@ -147,43 +183,43 @@ class Controller:
         for key in sensors_to_remove:
             self.status.sensors.pop(key)
 
-    def get_average_temp(self):
+    def _get_average_temp(self):
         temp_sum = 0
         sensor_keys = self.status.sensors.keys()
         for key in sensor_keys:
             temp_sum += self.status.sensors[key]["temperature"]
         return temp_sum / len(sensor_keys)
 
-    def fan_low_on(self):
+    def _fan_low_on(self):
         self.log.info("Turning on cooler to low")
         print("Turning on cooler to low")
         if self.status.usable.cooler:
-            self.set_pins(True, True, False, False)
+            self._set_pins(True, True, False, False)
         else:
-            self.all_off()
+            self._all_off()
 
-    def ac_on(self):
+    def _ac_on(self):
         self.log.info("Turning on ac")
         print("Turning on ac")
         if self.status.usable.ac:
-            self.set_pins(False, False, True, False)
+            self._set_pins(False, False, True, False)
         else:
-            self.all_off()
+            self._all_off()
 
-    def furnace_on(self):
+    def _furnace_on(self):
         self.log.info("Turning on furnace")
         print("Turning on furnace")
         if self.status.usable.furnace:
-            self.set_pins(False, False, False, True)
+            self._set_pins(False, False, False, True)
         else:
-            self.all_off()
+            self._all_off()
 
-    def all_off(self):
+    def _all_off(self):
         self.log.info("Turning cooler and furnace off")
         print("Turning cooler and furnace off")
-        self.set_pins(False, False, False, False)
+        self._set_pins(False, False, False, False)
 
-    def set_pins(self, pump: bool, fan_on: bool, ac: bool, furnace: bool):
+    def _set_pins(self, pump: bool, fan_on: bool, ac: bool, furnace: bool):
         pins_status = models.Pins(
             pump=pump, fan_on=fan_on, ac=ac, furnace=furnace)
         self.status.pins = pins_status
@@ -204,7 +240,7 @@ class Controller:
         GPIO.output(AC_PIN, ac_pin)
         GPIO.output(FURNACE_PIN, furnace_pin)
 
-    def write_status(self):
-        f = open("status.json", "w")
-        f.write(self.status.json())
-        f.close()
+    def _write_status(self):
+        with open("status.json", "w", encoding="utf-8") as f:
+            f.write(self.status.json())
+            f.close()

--- a/daemon/database.py
+++ b/daemon/database.py
@@ -3,40 +3,43 @@ import asyncpg
 
 
 class Database:
-  def __init__(self, log):
-    self.db_connection = None
-    self.log = log
-    self.user = ""
-    self.password = ""
-    self.database = ""
-    self.host = ""
+    def __init__(self, log):
+        self.db_connection = None
+        self.log = log
+        self.user = ""
+        self.password = ""
+        self.database = ""
+        self.host = ""
 
+    async def connect_db(
+            self,
+            user: str,
+            password: str,
+            database: str,
+            host: str):
+        self.user = user
+        self.password = password
+        self.database = database
+        self.host = host
+        self.log.info("Connecting to database at host " + host)
+        print("Connecting to database at host", host)
+        try:
+            self.db_connection = await asyncpg.connect(user=user, password=password,
+                                                       database=database, host=host)
+        except Exception as e:
+            self.log.error("Database connection failed with:\n" + str(e))
+            print("Database connection failed with:")
+            print(str(e))
+        else:
+            self.log.error("Database connection successful")
+            print("Database connection successful")
+        await self.create_tables()
 
-  async def connect_db(self, user: str, password: str, database: str, host: str):
-    self.user = user
-    self.password = password
-    self.database = database
-    self.host = host
-    self.log.info("Connecting to database at host " + host)
-    print("Connecting to database at host", host)
-    try:
-      self.db_connection = await asyncpg.connect(user=user, password=password,
-        database=database, host=host)
-    except Exception as e:
-      self.log.error("Database connection failed with:\n" + str(e))
-      print("Database connection failed with:")
-      print(str(e))
-    else:
-      self.log.error("Database connection successful")
-      print("Database connection successful")
-    await self.create_tables()
-
-
-  async def create_tables(self):
-    self.log.info("Sending requests to create tables on database")
-    print("Sending requests to create tables on database")
-    create_table_queries = [
-        """
+    async def create_tables(self):
+        self.log.info("Sending requests to create tables on database")
+        print("Sending requests to create tables on database")
+        create_table_queries = [
+            """
         CREATE TABLE IF NOT EXISTS sensors (
             time timestamptz,
             sensor_id text,
@@ -44,14 +47,14 @@ class Database:
             humidity real
         )
         """,
-        """
+            """
         CREATE TABLE IF NOT EXISTS averages (
             time timestamptz,
             average_temp real,
             target_temp real
         )
         """,
-        """
+            """
         CREATE TABLE IF NOT EXISTS pins (
             time timestamptz,
             pump_available bool,
@@ -64,82 +67,77 @@ class Database:
             fan_active bool
         )
         """
-    ]
-    try:
-      for query in create_table_queries:
-        await self.db_connection.execute(query)
-        print(f"Executed: {query.strip().splitlines()[0]}...")
-    except Exception as e:
-      self.log.error("Database query failed with:\n" + str(e))
-      print("Database query failed with:")
-      print(str(e))
+        ]
+        try:
+            for query in create_table_queries:
+                await self.db_connection.execute(query)
+                print(f"Executed: {query.strip().splitlines()[0]}...")
+        except Exception as e:
+            self.log.error("Database query failed with:\n" + str(e))
+            print("Database query failed with:")
+            print(str(e))
 
+    async def disconnect_db(self):
+        self.log.info("Disconnecting from database")
+        print("Disonnecting from database")
+        if self.db_connection:
+            await self.db_connection.close()
 
-  async def disconnect_db(self):
-    self.log.info("Disconnecting from database")
-    print("Disonnecting from database")
-    if self.db_connection:
-      await self.db_connection.close()
+    async def check_connection(self):
+        if self.db_connection is None or self.db_connection.is_closed():
+            await self.connect_db(self.user, self.password, self.database, self.host)
 
+    async def update_sensors(self, name, temperature, humidity):
+        await self.check_connection()
+        self.log.info("Sending sensor status to database")
+        print("Sending sensor status to database")
 
-  async def check_connection(self):
-    if self.db_connection == None or self.db_connection.is_closed():
-      await self.connect_db(self.user, self.password, self.database, self.host)
+        try:
+            dt = datetime.now()
 
+            await self.db_connection.execute(
+                "INSERT INTO sensors VALUES ($1, $2, $3, $4)",
+                dt, name, temperature, humidity
+            )
+        except Exception as e:
+            self.log.error("Database query failed with:\n" + str(e))
+            print("Database query failed with:")
+            print(str(e))
 
-  async def update_sensors(self, name, temperature, humidity):
-    await self.check_connection()
-    self.log.info("Sending sensor status to database")
-    print("Sending sensor status to database")
+    async def update_averages(self, avg_temp, target_temp):
+        await self.check_connection()
+        self.log.info("Sending averages to database")
+        print("Sending averages to database")
 
-    try:
-      dt = datetime.now()
+        try:
+            dt = datetime.now()
 
-      await self.db_connection.execute(
-        "INSERT INTO sensors VALUES ($1, $2, $3, $4)",
-        dt, name, temperature, humidity
-      )
-    except Exception as e:
-      self.log.error("Database query failed with:\n" + str(e))
-      print("Database query failed with:")
-      print(str(e))
+            await self.db_connection.execute(
+                "INSERT INTO averages VALUES ($1, $2, $3)",
+                dt, avg_temp, target_temp
+            )
+        except Exception as e:
+            self.log.error("Database query failed with:\n" + str(e))
+            print("Database query failed with:")
+            print(str(e))
 
+    async def update_pins(self, pins, usable):
+        await self.check_connection()
+        self.log.info("Sending pins to database")
+        print("Sending pins to database")
 
-  async def update_averages(self, avg_temp, target_temp):
-    await self.check_connection()
-    self.log.info("Sending averages to database")
-    print("Sending averages to database")
+        try:
+            dt = datetime.now()
 
-    try:
-      dt = datetime.now()
-
-      await self.db_connection.execute(
-        "INSERT INTO averages VALUES ($1, $2, $3)",
-        dt, avg_temp, target_temp
-      )
-    except Exception as e:
-      self.log.error("Database query failed with:\n" + str(e))
-      print("Database query failed with:")
-      print(str(e))
-
-
-  async def update_pins(self, pins, usable):
-    await self.check_connection()
-    self.log.info("Sending pins to database")
-    print("Sending pins to database")
-
-    try:
-      dt = datetime.now()
-
-      await self.db_connection.execute(
-        "INSERT INTO pins VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
-        dt,
-        usable.cooler, pins.pump,
-        usable.ac, pins.ac,
-        usable.furnace, pins.furnace,
-        usable.cooler, pins.fan_on
-      )
-    except Exception as e:
-      self.log.error("Database query failed with:\n" + str(e))
-      print("Database query failed with:")
-      print(str(e))
+            await self.db_connection.execute(
+                "INSERT INTO pins VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                dt,
+                usable.cooler, pins.pump,
+                usable.ac, pins.ac,
+                usable.furnace, pins.furnace,
+                usable.cooler, pins.fan_on
+            )
+        except Exception as e:
+            self.log.error("Database query failed with:\n" + str(e))
+            print("Database query failed with:")
+            print(str(e))

--- a/daemon/database.py
+++ b/daemon/database.py
@@ -1,8 +1,12 @@
+"""
+Sends queries to postgres database
+"""
 from datetime import datetime
 import asyncpg
 
 
 class Database:
+    """Handles connecting to, and sending queries to a postgres database."""
     def __init__(self, log):
         self.db_connection = None
         self.log = log
@@ -17,6 +21,10 @@ class Database:
             password: str,
             database: str,
             host: str):
+        """
+        Connects to and authenticates with database.
+        Sends queries to create necessary tables if they don't exist.
+        """
         self.user = user
         self.password = password
         self.database = database
@@ -33,9 +41,78 @@ class Database:
         else:
             self.log.error("Database connection successful")
             print("Database connection successful")
-        await self.create_tables()
+        await self._create_tables()
 
-    async def create_tables(self):
+    async def disconnect_db(self):
+        """Closes connection to database."""
+        self.log.info("Disconnecting from database")
+        print("Disonnecting from database")
+        if self.db_connection:
+            await self.db_connection.close()
+
+    async def update_sensors(self, name, temperature, humidity):
+        """Adds entry to sensors table of the database using the current timestamp."""
+        await self._check_connection()
+        self.log.info("Sending sensor status to database")
+        print("Sending sensor status to database")
+
+        try:
+            dt = datetime.now()
+
+            await self.db_connection.execute(
+                "INSERT INTO sensors VALUES ($1, $2, $3, $4)",
+                dt, name, temperature, humidity
+            )
+        except Exception as e:
+            self.log.error("Database query failed with:\n" + str(e))
+            print("Database query failed with:")
+            print(str(e))
+
+    async def update_averages(self, avg_temp, target_temp):
+        """Adds entry to averages table using current timestamp"""
+        await self._check_connection()
+        self.log.info("Sending averages to database")
+        print("Sending averages to database")
+
+        try:
+            dt = datetime.now()
+
+            await self.db_connection.execute(
+                "INSERT INTO averages VALUES ($1, $2, $3)",
+                dt, avg_temp, target_temp
+            )
+        except Exception as e:
+            self.log.error("Database query failed with:\n" + str(e))
+            print("Database query failed with:")
+            print(str(e))
+
+    async def update_pins(self, pins, usable):
+        """Adds entry to pins table of database"""
+        await self._check_connection()
+        self.log.info("Sending pins to database")
+        print("Sending pins to database")
+
+        try:
+            dt = datetime.now()
+
+            await self.db_connection.execute(
+                "INSERT INTO pins VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                dt,
+                usable.cooler, pins.pump,
+                usable.ac, pins.ac,
+                usable.furnace, pins.furnace,
+                usable.cooler, pins.fan_on
+            )
+        except Exception as e:
+            self.log.error("Database query failed with:\n" + str(e))
+            print("Database query failed with:")
+            print(str(e))
+
+    async def _check_connection(self):
+        if self.db_connection is None or self.db_connection.is_closed():
+            await self.connect_db(self.user, self.password, self.database, self.host)
+
+    async def _create_tables(self):
         self.log.info("Sending requests to create tables on database")
         print("Sending requests to create tables on database")
         create_table_queries = [
@@ -72,71 +149,6 @@ class Database:
             for query in create_table_queries:
                 await self.db_connection.execute(query)
                 print(f"Executed: {query.strip().splitlines()[0]}...")
-        except Exception as e:
-            self.log.error("Database query failed with:\n" + str(e))
-            print("Database query failed with:")
-            print(str(e))
-
-    async def disconnect_db(self):
-        self.log.info("Disconnecting from database")
-        print("Disonnecting from database")
-        if self.db_connection:
-            await self.db_connection.close()
-
-    async def check_connection(self):
-        if self.db_connection is None or self.db_connection.is_closed():
-            await self.connect_db(self.user, self.password, self.database, self.host)
-
-    async def update_sensors(self, name, temperature, humidity):
-        await self.check_connection()
-        self.log.info("Sending sensor status to database")
-        print("Sending sensor status to database")
-
-        try:
-            dt = datetime.now()
-
-            await self.db_connection.execute(
-                "INSERT INTO sensors VALUES ($1, $2, $3, $4)",
-                dt, name, temperature, humidity
-            )
-        except Exception as e:
-            self.log.error("Database query failed with:\n" + str(e))
-            print("Database query failed with:")
-            print(str(e))
-
-    async def update_averages(self, avg_temp, target_temp):
-        await self.check_connection()
-        self.log.info("Sending averages to database")
-        print("Sending averages to database")
-
-        try:
-            dt = datetime.now()
-
-            await self.db_connection.execute(
-                "INSERT INTO averages VALUES ($1, $2, $3)",
-                dt, avg_temp, target_temp
-            )
-        except Exception as e:
-            self.log.error("Database query failed with:\n" + str(e))
-            print("Database query failed with:")
-            print(str(e))
-
-    async def update_pins(self, pins, usable):
-        await self.check_connection()
-        self.log.info("Sending pins to database")
-        print("Sending pins to database")
-
-        try:
-            dt = datetime.now()
-
-            await self.db_connection.execute(
-                "INSERT INTO pins VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
-                dt,
-                usable.cooler, pins.pump,
-                usable.ac, pins.ac,
-                usable.furnace, pins.furnace,
-                usable.cooler, pins.fan_on
-            )
         except Exception as e:
             self.log.error("Database query failed with:\n" + str(e))
             print("Database query failed with:")

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -1,21 +1,24 @@
-from fastapi import FastAPI, Response, status
-from fastapi_utils.tasks import repeat_every
-from fastapi.middleware.cors import CORSMiddleware
-from contextlib import asynccontextmanager
+"""
+The entry point into the project.
+"""
+
+import logging
 import asyncio
+from contextlib import asynccontextmanager
+from systemd.journal import JournalHandler
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from controller import Controller
 from database import Database
 import models
-import logging
-from systemd.journal import JournalHandler
 import config
 
 log = logging.getLogger("thermostat")
 log.addHandler(JournalHandler())
 log.setLevel(logging.INFO)
 
-app = FastAPI()
 database = Database(log)
 controller = Controller(log)
 
@@ -23,107 +26,144 @@ is_shutdown = False
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-  try:
-    config.load_config()
-
-  except Exception as e:
-    log.info("Loading dot env file failed" + str(e))
-    print("Loading dot env file failed " + str(e))
-  if config.config["DATABASE"]["DB_ENABLED"] == "True":
-    try:
-      await database.connect_db(config.config["DATABASE"]["DB_USER"], config.config["DATABASE"]["DB_PASSWORD"],
-                                config.config["DATABASE"]["DB_DATABASE"], config.config["DATABASE"]["DB_HOST"])
-    except Exception as e:
-      log.info("Connecting to database failed with " + str(e))
-      print("Connecting to database failed with " + str(e))
-  else:
-    log.info("Database disabled in config")
-    print("Database disabled in config")
-  global is_shutdown
-  print("the lifespan is happening")
-  asyncio.create_task(drive_status_loop())
-  asyncio.create_task(drive_history_loop())
-  yield
-  if config.config["DATABASE"]["DB_ENABLED"] == "True":
-    await database.disconnect_db()
-  is_shutdown = True
+    """
+    Run when the program starts/terminates
+    """
+    await _startup()
+    yield
+    await _shutdown()
 
 app = FastAPI(lifespan=lifespan)
 
 origins = [
-  "*",
-  "https://raspberrypi.local"
+    "*",
+    "https://raspberrypi.local"
 ]
 
 
 app.add_middleware(
-  CORSMiddleware,
-  allow_origins=origins,
-  allow_credentials=True,
-  allow_methods=["*"],
-  allow_headers=["*"],
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
+
+async def _startup():
+    try:
+        config.load_config()
+    except Exception as e:
+        log.info("Loading dot env file failed %s", str(e))
+        print("Loading dot env file failed " + str(e))
+    if config.config["DATABASE"]["DB_ENABLED"] == "True":
+        try:
+            await database.connect_db(config.config["DATABASE"]["DB_USER"],
+                                      config.config["DATABASE"]["DB_PASSWORD"],
+                                      config.config["DATABASE"]["DB_DATABASE"],
+                                      config.config["DATABASE"]["DB_HOST"])
+        except Exception as e:
+            log.info("Connecting to database failed with %s", str(e))
+            print("Connecting to database failed with " + str(e))
+    else:
+        log.info("Database disabled in config")
+        print("Database disabled in config")
+    print("the lifespan is happening")
+    asyncio.create_task(drive_status_loop())
+    asyncio.create_task(drive_history_loop())
+
+
+async def _shutdown():
+    if config.config["DATABASE"]["DB_ENABLED"] == "True":
+        await database.disconnect_db()
+    global is_shutdown
+    is_shutdown = True
 
 
 async def drive_status_loop():
-  global is_shutdown
-  while (not is_shutdown):
-    print("Driving status loop")
-    drive_status()
-    if config.config["DATABASE"]["DB_ENABLED"] == "True":
-      await database.update_averages(controller.status.average_temp, controller.status.target_temp)
-      await database.update_pins(controller.status.pins, controller.status.usable)
-    await asyncio.sleep(10)
+    """
+    Creates a heartbeat driving the thermostat's status every 'interval_seconds'.
+    Also logs the status to the database if available.
+
+    Caution: Will block forever if awaited. Use as async task instead.
+    """
+    interval_seconds = 10
+    global is_shutdown
+    while not is_shutdown:
+        print("Driving status loop")
+        controller.drive_status()
+        if config.config["DATABASE"]["DB_ENABLED"] == "True":
+            await database.update_averages(controller.status.average_temp,
+                                           controller.status.target_temp)
+            await database.update_pins(controller.status.pins, controller.status.usable)
+        await asyncio.sleep(interval_seconds)
 
 
 async def drive_history_loop():
-  global is_shutdown
-  while (not is_shutdown):
-    print("Driving history loop")
-    controller.update_history()
-    await asyncio.sleep(120)
+    """
+    Creates a heartbeat to update history data.
 
-
-def drive_status():
-  try:
-    controller.drive_status()
-  except asyncio.CancelledError:
-    pass
+    Caution: Will block forever if awaited. Use as async task instead.
+    """
+    global is_shutdown
+    while not is_shutdown:
+        print("Driving history loop")
+        controller.update_history()
+        await asyncio.sleep(120)
 
 
 @app.get("/", response_model=models.StatusObject)
 async def root() -> dict:
-  return models.StatusObject(status = controller.get_status())
+    """
+    Returns the current status of the thermostat.
+    """
+    return models.StatusObject(status = controller.get_status())
 
 
 @app.get("/history")
 async def get_history() -> models.HistoryObject:
-  return models.HistoryObject(history = controller.get_history())
+    """
+    Returns a list of tuples containing timestamps and temperature.
+    """
+    return models.HistoryObject(history = controller.get_history())
 
 
 @app.put("/sensor-status")
 async def update_sensor_status(name: str, temperature: float, humidity: float):
-  controller.update_sensor_status(name, temperature, humidity)
-  if config.config["DATABASE"]["DB_ENABLED"] == "True":
-    await database.update_sensors(name, temperature, humidity)
+    """
+    Adds or updates an entry to the sensors list keyed by `name`.
+    """
+    controller.update_sensor_status(name, temperature, humidity)
+    if config.config["DATABASE"]["DB_ENABLED"] == "True":
+        await database.update_sensors(name, temperature, humidity)
 
-  return "Success"
+    return "Success"
 
 
 @app.put("/target_temperature")
 async def set_target_temp(temperature: int) -> str:
-  controller.set_target_temp(temperature)
-  return "Temperature set to {} degrees fahrenheit".format(temperature)
+    """
+    Changes the average temperature the thermostat aims for.
+    """
+    controller.set_target_temp(temperature)
+    return f"Temperature set to f{temperature} degrees fahrenheit"
 
 
 @app.put("/usable")
 async def set_usable(ac: bool, cooler: bool, furnace: bool):
-  controller.set_usable(ac, cooler, furnace)
-  return "Success"
+    """
+    Enables/disables the systems.
+    """
+    controller.set_usable(ac, cooler, furnace)
+    return "Success"
 
 
 @app.put("/manual_override")
 async def manual_override(override: bool, pins: models.Pins):
-  print(override, pins)
-  controller.set_manual_override(override, pins)
-  return "Success"
+    """
+    Overrides the pins to manually turn them on or off.
+
+    Be careful using this if the system is hooked up to a real HVAC system.
+    """
+    print(override, pins)
+    controller.set_manual_override(override, pins)
+    return "Success"

--- a/daemon/models.py
+++ b/daemon/models.py
@@ -1,30 +1,31 @@
 from pydantic import BaseModel
 
+
 class Pins(BaseModel):
-  pump: bool
-  fan_on: bool
-  ac: bool
-  furnace: bool
+    pump: bool
+    fan_on: bool
+    ac: bool
+    furnace: bool
 
 
 class Usable(BaseModel):
-  ac: bool
-  cooler: bool
-  furnace: bool
+    ac: bool
+    cooler: bool
+    furnace: bool
 
 
 class Status(BaseModel):
-  pins: Pins
-  usable: Usable
-  target_temp: int
-  average_temp: float
-  manual_override: bool
-  sensors: dict[str, dict]
+    pins: Pins
+    usable: Usable
+    target_temp: int
+    average_temp: float
+    manual_override: bool
+    sensors: dict[str, dict]
 
 
 class StatusObject(BaseModel):
-  status: Status
+    status: Status
 
 
 class HistoryObject(BaseModel):
-  history: list 
+    history: list

--- a/daemon/models.py
+++ b/daemon/models.py
@@ -1,7 +1,10 @@
+"""Defines datatypes FastAPI can send/receive."""
+
 from pydantic import BaseModel
 
 
 class Pins(BaseModel):
+    """GPIO pin state."""
     pump: bool
     fan_on: bool
     ac: bool
@@ -9,12 +12,14 @@ class Pins(BaseModel):
 
 
 class Usable(BaseModel):
+    """Whether each system can be turned on."""
     ac: bool
     cooler: bool
     furnace: bool
 
 
 class Status(BaseModel):
+    """Entire state of thermostat"""
     pins: Pins
     usable: Usable
     target_temp: int


### PR DESCRIPTION
Fixed as many Pylint warnings as I could in order to fully comply with PEP-8.

The main warning that remains is broadly catching `Exception` and not being specific.
Pylint also throws errors claiming we're referencing RPi.GPIO functions/variables that don't exist, even though they do, in fact, exist.